### PR TITLE
feat: add onboarding nickname

### DIFF
--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <external-path
+        name="my_images"
+        path="Android/data/org.projects.cameraapp/files/Pictures" />
+
+</paths>

--- a/data/src/main/java/com/someverse/data/impl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/someverse/data/impl/AuthRepositoryImpl.kt
@@ -21,119 +21,128 @@ import javax.inject.Inject
  * Use UserRepository.getCurrentUser() to fetch user after OAuth.
  */
 class AuthRepositoryImpl
-    @Inject
-    constructor(
-        private val dataSource: AuthDataSource, // Interface, not concrete class!
-    ) : AuthRepository {
-        // ==================== Authentication ====================
+@Inject
+constructor(
+    private val dataSource: AuthDataSource, // Interface, not concrete class!
+) : AuthRepository {
+    // ==================== Authentication ====================
 
-        override suspend fun getAuthStatus(): Result<AuthStatus> {
-            return try {
-                // Call dataSource to get auth status from API
-                val (userEntity, onboardingCompleted) = dataSource.getAuthStatus()
+    override suspend fun getAuthStatus(): Result<AuthStatus> {
+        return try {
+            // Call dataSource to get auth status from API
+            val (userEntity, onboardingCompleted) = dataSource.getAuthStatus()
 
-                // Validate required fields
-                if (userEntity.email.isNullOrBlank()) {
-                    return Result.failure(IllegalStateException("Email is required in auth status"))
-                }
-
-                // Map UserEntity to AuthStatus (lightweight model)
-                val authStatus =
-                    AuthStatus(
-                        userId = userEntity.id,
-                        email = userEntity.email,
-                        realName = userEntity.realName,
-                        provider = SocialProvider.fromString(userEntity.provider),
-                        onboardingCompleted = onboardingCompleted,
-                    )
-
-                Result.success(authStatus)
-            } catch (e: Exception) {
-                Result.failure(e)
+            // Validate required fields
+            if (userEntity.email.isNullOrBlank()) {
+                return Result.failure(IllegalStateException("Email is required in auth status"))
             }
+
+            // Map UserEntity to AuthStatus (lightweight model)
+            val authStatus =
+                AuthStatus(
+                    userId = userEntity.id,
+                    email = userEntity.email,
+                    realName = userEntity.realName,
+                    provider = SocialProvider.fromString(userEntity.provider),
+                    onboardingCompleted = onboardingCompleted,
+                )
+
+            Result.success(authStatus)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
-
-        override suspend fun logout(): Result<Unit> =
-            try {
-                dataSource.logout()
-                Result.success(Unit)
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-
-        override suspend fun refreshToken(refreshToken: String): Result<AuthToken> =
-            try {
-                val tokenEntity = dataSource.refreshToken(refreshToken)
-                Result.success(tokenEntity.toDomain())
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-
-        // ==================== Onboarding Steps ====================
-
-        override suspend fun submitNickname(nickname: String): Result<User> {
-            return try {
-                // Validate nickname (business logic)
-                if (nickname.isBlank()) {
-                    return Result.failure(Exception("Nickname cannot be empty"))
-                }
-
-                // Delegate to dataSource and get updated user
-                val userEntity = dataSource.submitNickname(nickname)
-                Result.success(userEntity.toDomain())
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-        }
-
-        override suspend fun submitGender(gender: Gender): Result<User> =
-            try {
-                val userEntity = dataSource.submitGender(gender)
-                Result.success(userEntity.toDomain())
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-
-        override suspend fun submitAge(age: Int): Result<User> {
-            return try {
-                // Validate age (business logic)
-                if (age < 0 || age > 150) {
-                    return Result.failure(Exception("Invalid age"))
-                }
-
-                val userEntity = dataSource.submitAge(age)
-                Result.success(userEntity.toDomain())
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-        }
-
-        override suspend fun submitAddress(address: List<String>): Result<User> {
-            return try {
-                if (address.isEmpty()) {
-                    return Result.failure(Exception("Address list cannot be empty"))
-                }
-
-                val userEntity = dataSource.submitAddress(address)
-                Result.success(userEntity.toDomain())
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-        }
-
-        override suspend fun submitProfileImage(imageUrl: String): Result<User> =
-            try {
-                val userEntity = dataSource.submitProfileImage(imageUrl)
-                Result.success(userEntity.toDomain())
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-
-        override suspend fun getAddressList(): Result<List<Location>> =
-            try {
-                val locations = dataSource.getAddressList()
-                Result.success(locations)
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
     }
+
+    override suspend fun logout(): Result<Unit> =
+        try {
+            dataSource.logout()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    override suspend fun refreshToken(refreshToken: String): Result<AuthToken> =
+        try {
+            val tokenEntity = dataSource.refreshToken(refreshToken)
+            Result.success(tokenEntity.toDomain())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    // ==================== Onboarding Steps ====================
+
+    override suspend fun checkNickname(nickname: String): Result<Boolean> {
+        return try {
+            val result = dataSource.checkNickname(nickname)
+            Result.success(result)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun submitNickname(nickname: String): Result<User> {
+        return try {
+            // Validate nickname (business logic)
+            if (nickname.isBlank()) {
+                return Result.failure(Exception("Nickname cannot be empty"))
+            }
+
+            // Delegate to dataSource and get updated user
+            val userEntity = dataSource.submitNickname(nickname)
+            Result.success(userEntity.toDomain())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun submitGender(gender: Gender): Result<User> =
+        try {
+            val userEntity = dataSource.submitGender(gender)
+            Result.success(userEntity.toDomain())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    override suspend fun submitAge(age: Int): Result<User> {
+        return try {
+            // Validate age (business logic)
+            if (age < 0 || age > 150) {
+                return Result.failure(Exception("Invalid age"))
+            }
+
+            val userEntity = dataSource.submitAge(age)
+            Result.success(userEntity.toDomain())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun submitAddress(address: List<String>): Result<User> {
+        return try {
+            if (address.isEmpty()) {
+                return Result.failure(Exception("Address list cannot be empty"))
+            }
+
+            val userEntity = dataSource.submitAddress(address)
+            Result.success(userEntity.toDomain())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun submitProfileImage(imageUrl: String): Result<User> =
+        try {
+            val userEntity = dataSource.submitProfileImage(imageUrl)
+            Result.success(userEntity.toDomain())
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+
+    override suspend fun getAddressList(): Result<List<Location>> =
+        try {
+            val locations = dataSource.getAddressList()
+            Result.success(locations)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+}

--- a/data/src/main/java/com/someverse/data/local/AuthLocalDataSource.kt
+++ b/data/src/main/java/com/someverse/data/local/AuthLocalDataSource.kt
@@ -1,6 +1,9 @@
 package com.someverse.data.local
 
 import com.someverse.data.model.AuthTokenEntity
+import com.someverse.data.model.GenreEntity
+import com.someverse.data.model.LocationEntity
+import com.someverse.data.model.MovieEntity
 import com.someverse.data.model.UserEntity
 import com.someverse.data.source.AuthDataSource
 import com.someverse.domain.model.Gender
@@ -18,218 +21,258 @@ import javax.inject.Singleton
  */
 @Singleton
 class AuthLocalDataSource
-    @Inject
-    constructor() : AuthDataSource {
-        // In-memory storage
-        private var isAuthenticatedFlag = false
-        private var storedToken: AuthTokenEntity? = null
-        private var currentUser: UserEntity? = null
+@Inject
+constructor() : AuthDataSource {
+    // In-memory storage
+    private var isAuthenticatedFlag = false
+    private var storedToken: AuthTokenEntity? = null
+    private var currentUser: UserEntity? = UserEntity(
+        id = "user_10000",
+        nickname = "테스트",
+        age = 28,
+        gender = "MALE",
+        activityLocations = listOf(
+            LocationEntity("서울특별시", "강남구"),
+            LocationEntity("경기도", "성남시")
+        ),
+        profileImages = listOf(
+            "https://picsum.photos/id/1/200/300",
+            "https://picsum.photos/id/2/200/300"
+        ),
+        primaryImageUrl = "https://picsum.photos/id/1/200/300",
+        bio = "안녕하세요! 안드로이드 개발자입니다. 영화와 여행을 좋아해요.",
+        job = "Software Engineer",
+        favoriteMovies = listOf(
+            MovieEntity(1L, "인셉션", "https://picsum.photos/id/10/200/300"),
+            MovieEntity(2L, "인터스텔라", "https://picsum.photos/id/11/200/300")
+        ),
+        preferredGenres = listOf(
+            GenreEntity(1L, "SF"),
+            GenreEntity(2L, "액션"),
+            GenreEntity(3L, "스릴러")
+        ),
+        // OAuth 및 온보딩 관련 필드
+        email = "gemini@someverse.com",
+        realName = "김철수",
+        provider = "GOOGLE",
+        birthDate = "1996-05-20T00:00:00.000+00:00",
+        phone = "010-1234-5678",
+        onboardingCompleted = true,
+        onboardingStep = 1,
+        createdAt = System.currentTimeMillis(),
+        updatedAt = System.currentTimeMillis()
+    )
 
-        // ==================== Authentication ====================
+    private val existingNicknames = mutableSetOf("썸버스", "안드로이드", "제미나이", "관리자")
 
-        override suspend fun getAuthStatus(): Pair<UserEntity, Boolean> {
-            delay(500)
+    // ==================== Authentication ====================
 
-            // Generate mock auth status response (simulates GET /users/me)
-            // Note: This is a lightweight response, not full profile
-            val mockUser =
-                UserEntity(
-                    id = "user_${System.currentTimeMillis()}",
-                    nickname = null, // Not included in auth status response
-                    age = null,
-                    gender = "FEMALE",
-                    activityLocations = null,
-                    profileImages = null,
-                    primaryImageUrl = null,
-                    bio = null,
-                    job = null,
-                    favoriteMovies = null,
-                    preferredGenres = null,
-                    // OAuth-specific fields
-                    email = "user@example.com",
-                    realName = "홍길동",
-                    provider = "KAKAO",
-                    birthDate = "1997-03-17T00:00:00.000+00:00",
-                    phone = "01012345678",
-                    onboardingCompleted = false, // For testing onboarding flow
-                    onboardingStep = 0,
-                    createdAt = System.currentTimeMillis(),
-                    updatedAt = System.currentTimeMillis(),
-                )
+    override suspend fun getAuthStatus(): Pair<UserEntity, Boolean> {
+        delay(500)
 
-            saveUser(mockUser)
-
-            println("📱 Local: Auth status retrieved (Mock) - Onboarding: ${mockUser.onboardingCompleted}")
-            return Pair(mockUser, mockUser.onboardingCompleted)
-        }
-
-        override suspend fun logout() {
-            delay(200)
-            clearAuth()
-        }
-
-        override suspend fun refreshToken(refreshToken: String): AuthTokenEntity {
-            delay(300)
-
-            val newToken =
-                AuthTokenEntity(
-                    accessToken = "mock_refreshed_access_token_${System.currentTimeMillis()}",
-                    refreshToken = "mock_refreshed_refresh_token_${System.currentTimeMillis()}",
-                    expiresIn = 3600000,
-                    tokenType = "Bearer",
-                )
-
-            saveToken(newToken)
-            println(" Local: Token refreshed (Mock)")
-            return newToken
-        }
-
-        override suspend fun isAuthenticated(): Boolean {
-            delay(50)
-            return isAuthenticatedFlag && storedToken != null
-        }
-
-        override suspend fun clearAuth() {
-            delay(50)
-            storedToken = null
-            isAuthenticatedFlag = false
-            currentUser = null
-            println(" Local: Auth data cleared")
-        }
-
-        override suspend fun getToken(): AuthTokenEntity? {
-            delay(50)
-            return storedToken
-        }
-
-        override suspend fun saveToken(token: AuthTokenEntity) {
-            delay(50)
-            storedToken = token
-            isAuthenticatedFlag = true
-            println(" Local: Token saved")
-        }
-
-        // ==================== Onboarding Data ====================
-
-        override suspend fun submitNickname(nickname: String): UserEntity {
-            delay(100)
-
-            // TODO: Update based on actual backend API for onboarding
-            val updatedUser =
-                currentUser?.copy(
-                    realName = nickname, // Temporary: use realName for nickname
-                    updatedAt = System.currentTimeMillis(),
-                ) ?: throw IllegalStateException("No user logged in")
-
-            saveUser(updatedUser)
-            println(" Local: Nickname saved -> $nickname")
-            return updatedUser
-        }
-
-        override suspend fun submitGender(gender: Gender): UserEntity {
-            delay(100)
-
-            val updatedUser =
-                currentUser?.copy(
-                    gender = gender.name,
-                    updatedAt = System.currentTimeMillis(),
-                ) ?: throw IllegalStateException("No user logged in")
-
-            saveUser(updatedUser)
-            println(" Local: Gender saved -> $gender")
-            return updatedUser
-        }
-
-        override suspend fun submitAge(age: Int): UserEntity {
-            delay(100)
-
-            // TODO: Update based on actual backend API for age/birthDate
-            // For now, just update the user
-            val updatedUser =
-                currentUser?.copy(
-                    updatedAt = System.currentTimeMillis(),
-                ) ?: throw IllegalStateException("No user logged in")
-
-            saveUser(updatedUser)
-            println(" Local: Age saved -> $age")
-            return updatedUser
-        }
-
-        override suspend fun submitAddress(address: List<String>): UserEntity {
-            delay(100)
-
-            // TODO: Update based on actual backend API for address
-            val updatedUser =
-                currentUser?.copy(
-                    // In a real implementation, we would save the address list to a field
-                    // For now, just updating the timestamp as before
-                    updatedAt = System.currentTimeMillis(),
-                ) ?: throw IllegalStateException("No user logged in")
-
-            saveUser(updatedUser)
-            println(" Local: Addresses saved -> $address")
-            return updatedUser
-        }
-
-        override suspend fun submitProfileImage(imageUrl: String): UserEntity {
-            delay(100)
-
-            // Mark onboarding as completed when profile image is submitted (last step)
-            val updatedUser =
-                currentUser?.copy(
-                    primaryImageUrl = imageUrl,
-                    onboardingCompleted = true,
-                    updatedAt = System.currentTimeMillis(),
-                ) ?: throw IllegalStateException("No user logged in")
-
-            saveUser(updatedUser)
-            println(" Local: Profile image saved -> $imageUrl")
-            return updatedUser
-        }
-
-        // ==================== User Management ====================
-
-        override suspend fun getCurrentUser(): UserEntity? {
-            delay(50)
-            return currentUser
-        }
-
-        override suspend fun saveUser(user: UserEntity) {
-            delay(50)
-            currentUser = user
-        }
-
-        // ==================== Helper Methods ====================
-
-        /**
-         * Get all stored data (for debugging)
-         */
-        fun getAllData(): Map<String, Any?> =
-            mapOf(
-                "isAuthenticated" to isAuthenticatedFlag,
-                "token" to storedToken,
-                "user" to currentUser,
+        // Generate mock auth status response (simulates GET /users/me)
+        // Note: This is a lightweight response, not full profile
+        val mockUser =
+            UserEntity(
+                id = "user_${System.currentTimeMillis()}",
+                nickname = null, // Not included in auth status response
+                age = null,
+                gender = "FEMALE",
+                activityLocations = null,
+                profileImages = null,
+                primaryImageUrl = null,
+                bio = null,
+                job = null,
+                favoriteMovies = null,
+                preferredGenres = null,
+                // OAuth-specific fields
+                email = "user@example.com",
+                realName = "홍길동",
+                provider = "KAKAO",
+                birthDate = "1997-03-17T00:00:00.000+00:00",
+                phone = "01012345678",
+                onboardingCompleted = false, // For testing onboarding flow
+                onboardingStep = 0,
+                createdAt = System.currentTimeMillis(),
+                updatedAt = System.currentTimeMillis(),
             )
 
-        override suspend fun getAddressList(): List<Location> {
-            // Simulated delay
-            delay(300)
+        saveUser(mockUser)
 
-            // Return mock address list data
-            return listOf(
-                Location("서울특별시", "강남구"),
-                Location("서울특별시", "서초구"),
-                Location("서울특별시", "마포구"),
-                Location("서울특별시", "종로구"),
-                Location("서울특별시", "영등포구"),
-                Location("경기도", "성남시"),
-                Location("경기도", "수원시"),
-                Location("경기도", "화성시"),
-                Location("경기도", "의정부시"),
-                Location("부산광역시", "해운대구"),
-                Location("부산광역시", "중구"),
-                Location("인천광역시", "중구"),
-                Location("인천광역시", "연수구"),
-            )
-        }
+        println("📱 Local: Auth status retrieved (Mock) - Onboarding: ${mockUser.onboardingCompleted}")
+        return Pair(mockUser, mockUser.onboardingCompleted)
     }
+
+    override suspend fun logout() {
+        delay(200)
+        clearAuth()
+    }
+
+    override suspend fun refreshToken(refreshToken: String): AuthTokenEntity {
+        delay(300)
+
+        val newToken =
+            AuthTokenEntity(
+                accessToken = "mock_refreshed_access_token_${System.currentTimeMillis()}",
+                refreshToken = "mock_refreshed_refresh_token_${System.currentTimeMillis()}",
+                expiresIn = 3600000,
+                tokenType = "Bearer",
+            )
+
+        saveToken(newToken)
+        println(" Local: Token refreshed (Mock)")
+        return newToken
+    }
+
+    override suspend fun isAuthenticated(): Boolean {
+        delay(50)
+        return isAuthenticatedFlag && storedToken != null
+    }
+
+    override suspend fun clearAuth() {
+        delay(50)
+        storedToken = null
+        isAuthenticatedFlag = false
+        currentUser = null
+        println(" Local: Auth data cleared")
+    }
+
+    override suspend fun getToken(): AuthTokenEntity? {
+        delay(50)
+        return storedToken
+    }
+
+    override suspend fun saveToken(token: AuthTokenEntity) {
+        delay(50)
+        storedToken = token
+        isAuthenticatedFlag = true
+        println(" Local: Token saved")
+    }
+
+    // ==================== Onboarding Data ====================
+
+    override suspend fun checkNickname(nickname: String): Boolean {
+        return !existingNicknames.contains(nickname)
+    }
+
+    override suspend fun submitNickname(nickname: String): UserEntity {
+        delay(100)
+
+        // TODO: Update based on actual backend API for onboarding
+        val updatedUser =
+            currentUser?.copy(
+                realName = nickname, // Temporary: use realName for nickname
+                updatedAt = System.currentTimeMillis(),
+            ) ?: throw IllegalStateException("No user logged in")
+        saveUser(updatedUser)
+        println(" Local: Nickname saved -> $nickname")
+        return updatedUser
+    }
+
+    override suspend fun submitGender(gender: Gender): UserEntity {
+        delay(100)
+
+        val updatedUser =
+            currentUser?.copy(
+                gender = gender.name,
+                updatedAt = System.currentTimeMillis(),
+            ) ?: throw IllegalStateException("No user logged in")
+
+        saveUser(updatedUser)
+        println(" Local: Gender saved -> $gender")
+        return updatedUser
+    }
+
+    override suspend fun submitAge(age: Int): UserEntity {
+        delay(100)
+
+        // TODO: Update based on actual backend API for age/birthDate
+        // For now, just update the user
+        val updatedUser =
+            currentUser?.copy(
+                updatedAt = System.currentTimeMillis(),
+            ) ?: throw IllegalStateException("No user logged in")
+
+        saveUser(updatedUser)
+        println(" Local: Age saved -> $age")
+        return updatedUser
+    }
+
+    override suspend fun submitAddress(address: List<String>): UserEntity {
+        delay(100)
+
+        // TODO: Update based on actual backend API for address
+        val updatedUser =
+            currentUser?.copy(
+                // In a real implementation, we would save the address list to a field
+                // For now, just updating the timestamp as before
+                updatedAt = System.currentTimeMillis(),
+            ) ?: throw IllegalStateException("No user logged in")
+
+        saveUser(updatedUser)
+        println(" Local: Addresses saved -> $address")
+        return updatedUser
+    }
+
+    override suspend fun submitProfileImage(imageUrl: String): UserEntity {
+        delay(100)
+
+        // Mark onboarding as completed when profile image is submitted (last step)
+        val updatedUser =
+            currentUser?.copy(
+                primaryImageUrl = imageUrl,
+                onboardingCompleted = true,
+                updatedAt = System.currentTimeMillis(),
+            ) ?: throw IllegalStateException("No user logged in")
+
+        saveUser(updatedUser)
+        println(" Local: Profile image saved -> $imageUrl")
+        return updatedUser
+    }
+
+    // ==================== User Management ====================
+
+    override suspend fun getCurrentUser(): UserEntity? {
+        delay(50)
+        return currentUser
+    }
+
+    override suspend fun saveUser(user: UserEntity) {
+        delay(50)
+        currentUser = user
+    }
+
+    // ==================== Helper Methods ====================
+
+    /**
+     * Get all stored data (for debugging)
+     */
+    fun getAllData(): Map<String, Any?> =
+        mapOf(
+            "isAuthenticated" to isAuthenticatedFlag,
+            "token" to storedToken,
+            "user" to currentUser,
+        )
+
+    override suspend fun getAddressList(): List<Location> {
+        // Simulated delay
+        delay(300)
+
+        // Return mock address list data
+        return listOf(
+            Location("서울특별시", "강남구"),
+            Location("서울특별시", "서초구"),
+            Location("서울특별시", "마포구"),
+            Location("서울특별시", "종로구"),
+            Location("서울특별시", "영등포구"),
+            Location("경기도", "성남시"),
+            Location("경기도", "수원시"),
+            Location("경기도", "화성시"),
+            Location("경기도", "의정부시"),
+            Location("부산광역시", "해운대구"),
+            Location("부산광역시", "중구"),
+            Location("인천광역시", "중구"),
+            Location("인천광역시", "연수구"),
+        )
+    }
+}

--- a/data/src/main/java/com/someverse/data/remote/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/someverse/data/remote/AuthRemoteDataSource.kt
@@ -7,7 +7,6 @@ import com.someverse.data.source.AuthDataSource
 import com.someverse.domain.model.Gender
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.NotImplementedError
 
 /**
  * Auth Remote DataSource (Real API Implementation)
@@ -18,64 +17,68 @@ import kotlin.NotImplementedError
  */
 @Singleton
 class AuthRemoteDataSource
-    @Inject
-    constructor(
-        private val authApiService: AuthApiService,
-    ) : AuthDataSource {
-        // For caching
-        private var cachedToken: AuthTokenEntity? = null
-        private var cachedUser: UserEntity? = null
+@Inject
+constructor(
+    private val authApiService: AuthApiService,
+) : AuthDataSource {
+    // For caching
+    private var cachedToken: AuthTokenEntity? = null
+    private var cachedUser: UserEntity? = null
 
-        // ==================== Authentication ====================
+    // ==================== Authentication ====================
 
-        override suspend fun getAuthStatus(): Pair<UserEntity, Boolean> =
-            throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+    override suspend fun getAuthStatus(): Pair<UserEntity, Boolean> =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
 
-        override suspend fun logout(): Unit = throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+    override suspend fun logout(): Unit =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
 
-        override suspend fun refreshToken(refreshToken: String): AuthTokenEntity =
-            throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+    override suspend fun refreshToken(refreshToken: String): AuthTokenEntity =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
 
-        override suspend fun isAuthenticated(): Boolean = cachedToken != null && cachedUser != null
+    override suspend fun isAuthenticated(): Boolean = cachedToken != null && cachedUser != null
 
-        override suspend fun clearAuth() {
-            cachedToken = null
-            cachedUser = null
-        }
-
-        override suspend fun getToken(): AuthTokenEntity? = cachedToken
-
-        override suspend fun saveToken(token: AuthTokenEntity) {
-            cachedToken = token
-        }
-
-        // ==================== Onboarding Data ====================
-
-        override suspend fun submitNickname(nickname: String): UserEntity =
-            throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
-
-        override suspend fun submitGender(gender: Gender): UserEntity =
-            throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
-
-        override suspend fun submitAge(age: Int): UserEntity =
-            throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
-
-        override suspend fun submitAddress(address: List<String>): UserEntity =
-            throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
-
-        override suspend fun submitProfileImage(imageUrl: String): UserEntity =
-            throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
-
-        // ==================== User Management ====================
-
-        override suspend fun getCurrentUser(): UserEntity? = cachedUser
-
-        override suspend fun saveUser(user: UserEntity) {
-            cachedUser = user
-        }
-
-        override suspend fun getAddressList(): List<com.someverse.domain.model.Location> {
-            // TODO: Implement real API call when backend is ready
-            throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
-        }
+    override suspend fun clearAuth() {
+        cachedToken = null
+        cachedUser = null
     }
+
+    override suspend fun getToken(): AuthTokenEntity? = cachedToken
+
+    override suspend fun saveToken(token: AuthTokenEntity) {
+        cachedToken = token
+    }
+
+    // ==================== Onboarding Data ====================
+
+    override suspend fun checkNickname(nickname: String): Boolean =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+
+    override suspend fun submitNickname(nickname: String): UserEntity =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+
+    override suspend fun submitGender(gender: Gender): UserEntity =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+
+    override suspend fun submitAge(age: Int): UserEntity =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+
+    override suspend fun submitAddress(address: List<String>): UserEntity =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+
+    override suspend fun submitProfileImage(imageUrl: String): UserEntity =
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+
+    // ==================== User Management ====================
+
+    override suspend fun getCurrentUser(): UserEntity? = cachedUser
+
+    override suspend fun saveUser(user: UserEntity) {
+        cachedUser = user
+    }
+
+    override suspend fun getAddressList(): List<com.someverse.domain.model.Location> {
+        // TODO: Implement real API call when backend is ready
+        throw NotImplementedError("Remote API not implemented yet. Use AuthLocalDataSource.")
+    }
+}

--- a/data/src/main/java/com/someverse/data/source/AuthDataSource.kt
+++ b/data/src/main/java/com/someverse/data/source/AuthDataSource.kt
@@ -59,6 +59,8 @@ interface AuthDataSource {
      * Submit nickname
      * @return Updated UserEntity
      */
+    suspend fun checkNickname(nickname: String): Boolean
+
     suspend fun submitNickname(nickname: String): UserEntity
 
     /**

--- a/domain/src/main/java/com/someverse/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/someverse/domain/repository/AuthRepository.kt
@@ -45,6 +45,8 @@ interface AuthRepository {
      * Submit nickname (Step 1)
      * @return Updated User with nickname
      */
+    suspend fun checkNickname(nickname: String): Result<Boolean>
+
     suspend fun submitNickname(nickname: String): Result<User>
 
     /**

--- a/domain/src/main/java/com/someverse/domain/usecase/onboarding/SubmitNicknameUseCase.kt
+++ b/domain/src/main/java/com/someverse/domain/usecase/onboarding/SubmitNicknameUseCase.kt
@@ -47,7 +47,7 @@ constructor(
                 if (!result) {
                     // Delegate to repository
                     return Result.failure(
-                        IllegalArgumentException("Nickname is duplicated")
+                        IllegalArgumentException("이미 사용중인 닉네임이에요.")
                     )
                 }
             }.onFailure {

--- a/domain/src/main/java/com/someverse/domain/usecase/onboarding/SubmitNicknameUseCase.kt
+++ b/domain/src/main/java/com/someverse/domain/usecase/onboarding/SubmitNicknameUseCase.kt
@@ -11,37 +11,52 @@ import javax.inject.Inject
  * - Delegates to AuthRepository
  */
 class SubmitNicknameUseCase
-    @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-    ) {
-        /**
-         * Submit user nickname
-         *
-         * @param nickname User's chosen nickname, 2~8자
-         * @return Result<User> updated user with nickname or failure with validation error
-         */
-        suspend operator fun invoke(nickname: String): Result<User> {
-            // Business logic: Validate nickname
-            if (nickname.isBlank()) {
-                return Result.failure(
-                    IllegalArgumentException("Nickname cannot be blank"),
-                )
-            }
-
-            if (nickname.length < 2) {
-                return Result.failure(
-                    IllegalArgumentException("Nickname must be at least 2 characters"),
-                )
-            }
-
-            if (nickname.length > 8) {
-                return Result.failure(
-                    IllegalArgumentException("Nickname must be less than 9 characters"),
-                )
-            }
-
-            // Delegate to repository
-            return authRepository.submitNickname(nickname)
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+) {
+    /**
+     * Submit user nickname
+     *
+     * @param nickname User's chosen nickname, 2~8자
+     * @return Result<User> updated user with nickname or failure with validation error
+     */
+    suspend operator fun invoke(nickname: String): Result<User> {
+        // Business logic: Validate nickname
+        if (nickname.isBlank()) {
+            return Result.failure(
+                IllegalArgumentException("Nickname cannot be blank"),
+            )
         }
+
+        if (nickname.length < 2) {
+            return Result.failure(
+                IllegalArgumentException("Nickname must be at least 2 characters"),
+            )
+        }
+
+        if (nickname.length > 8) {
+            return Result.failure(
+                IllegalArgumentException("Nickname must be less than 9 characters"),
+            )
+        }
+
+        // 중복 확인
+        authRepository.checkNickname(nickname)
+            .onSuccess { result ->
+                if (!result) {
+                    // Delegate to repository
+                    return Result.failure(
+                        IllegalArgumentException("Nickname is duplicated")
+                    )
+                }
+            }.onFailure {
+                return Result.failure(
+                    IllegalArgumentException("error")
+                )
+            }
+
+
+        return authRepository.submitNickname(nickname)
     }
+}

--- a/presentation/src/main/java/com/someverse/presentation/components/PageIndicator.kt
+++ b/presentation/src/main/java/com/someverse/presentation/components/PageIndicator.kt
@@ -1,0 +1,51 @@
+package com.someverse.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.someverse.presentation.ui.theme.PrimaryPurple
+
+@Composable
+fun PageIndicator(isActive: Boolean) {
+    Box(
+        modifier = Modifier
+            .size(
+                width = if (isActive) 32.dp else 8.dp,
+                height = 8.dp
+            )
+            .clip(CircleShape)
+            .background(
+                if (isActive) PrimaryPurple else Color(0xFFE4E8EF)
+            )
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PageIndicatorPreView() {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(bottom = 24.dp),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        repeat(5) { index ->
+            PageIndicator(isActive = index == 0)
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+    }
+}

--- a/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
+++ b/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
@@ -1,11 +1,15 @@
 package com.someverse.presentation.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -16,19 +20,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.someverse.presentation.R
 import com.someverse.presentation.ui.theme.DescGray
+import com.someverse.presentation.ui.theme.Dimensions
 import com.someverse.presentation.ui.theme.PretendardFontFamily
 import com.someverse.presentation.ui.theme.withLetterSpacingPercent
 
 @Composable
 fun SomeVerseTopBar(
     modifier: Modifier = Modifier,
-    title: String = "",
+    textTitle: String? = null,
+    titleImage: Boolean = false,
     leadingIcon: (@Composable () -> Unit)? = null,
     trailingIcon: (@Composable () -> Unit)? = null
 ) {
@@ -36,36 +41,55 @@ fun SomeVerseTopBar(
         modifier = modifier
             .fillMaxWidth()
             .height(height = 52.dp)
+            .padding(horizontal = 30.dp)
             .background(color = Color(0xffFAFAFA))
     ) {
         // 좌측 아이콘
-        Box(
-            modifier = modifier
-                .padding(horizontal = 30.dp)
-                .align(Alignment.CenterStart)
-        ) {
-            leadingIcon?.invoke()
+        if (leadingIcon != null) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+            ) {
+                leadingIcon()
+            }
         }
-        // 제목
-        Text(
-            text = title, style = MaterialTheme.typography.titleMedium
-                .copy(
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 20.sp,
-                    lineHeight = 32.sp,
-                    textAlign = TextAlign.Center,
-                    fontFamily = PretendardFontFamily,
-                ).withLetterSpacingPercent(-2.5f),
-            color = DescGray,
-            modifier = modifier.align(Alignment.Center)
-        )
+
+        // 텍스트 제목
+        if (textTitle != null) {
+            Text(
+                text = textTitle, style = MaterialTheme.typography.titleMedium
+                    .copy(
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 20.sp,
+                        lineHeight = 32.sp,
+                        fontFamily = PretendardFontFamily,
+                    ).withLetterSpacingPercent(-2.5f),
+                color = DescGray,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+
+        // 이미지 제목
+        if (titleImage) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_logo_with_text),
+                contentDescription = "SOMEVERSE 로고",
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = if (leadingIcon != null) 60.dp else Dimensions.space16)
+                    .width(108.dp)
+                    .height(20.dp)
+            )
+        }
+
         // 우측 아이콘
-        Box(
-            modifier = modifier
-                .padding(horizontal = 30.dp)
-                .align(Alignment.CenterEnd)
-        ) {
-            trailingIcon?.invoke()
+        if (trailingIcon != null) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+            ) {
+                trailingIcon()
+            }
         }
     }
 }
@@ -73,31 +97,53 @@ fun SomeVerseTopBar(
 @Composable
 @Preview(showBackground = true)
 fun SomeVerseTopBarPreview() {
-    SomeVerseTopBar(
-        title = "취향 입력",
-        leadingIcon = {
-            IconButton(
-                onClick = {}
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_dismiss),
-                    contentDescription = "뒤로가기",
-                    tint = Color(0xFF9098A6),
-                    modifier = Modifier.size(size = 28.dp)
-                )
+    val iconColor = Color(0xFF9098A6)
+    Column() {
+        SomeVerseTopBar(
+            textTitle = "취향 입력",
+            leadingIcon = {
+                IconButton(
+                    onClick = {}
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_dismiss),
+                        contentDescription = "뒤로가기",
+                        tint = iconColor,
+                        modifier = Modifier.size(size = 28.dp)
+                    )
+                }
+            },
+            trailingIcon = {
+                IconButton(
+                    onClick = {}
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_search),
+                        contentDescription = "신고",
+                        tint = iconColor,
+                        modifier = Modifier.size(size = 20.dp)
+                    )
+                }
             }
-        },
-        trailingIcon = {
-            IconButton(
-                onClick = {}
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_search),
-                    contentDescription = "신고",
-                    tint = Color(0xff9098A6),
-                    modifier = Modifier.size(size = 20.dp)
-                )
-            }
-        }
-    )
+        )
+
+        Spacer(modifier = Modifier.height(Dimensions.space12))
+
+        SomeVerseTopBar(
+            leadingIcon = {
+                IconButton(
+                    onClick = {}
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_dismiss),
+                        contentDescription = "뒤로가기",
+                        tint = iconColor,
+                        modifier = Modifier.size(size = 28.dp)
+                    )
+                }
+            },
+            titleImage = true
+        )
+    }
+
 }

--- a/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
+++ b/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
@@ -41,7 +41,7 @@ fun SomeVerseTopBar(
         modifier = modifier
             .fillMaxWidth()
             .height(height = 52.dp)
-            .background(color = Color(0xffFAFAFA))
+            .background(color = Color(0xffFFFFFF))
             .padding(horizontal = 30.dp)
     ) {
         // 좌측 아이콘

--- a/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
+++ b/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
@@ -1,0 +1,103 @@
+package com.someverse.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.someverse.presentation.R
+import com.someverse.presentation.ui.theme.DescGray
+import com.someverse.presentation.ui.theme.PretendardFontFamily
+import com.someverse.presentation.ui.theme.withLetterSpacingPercent
+
+@Composable
+fun SomeVerseTopBar(
+    modifier: Modifier = Modifier,
+    title: String = "",
+    leadingIcon: (@Composable () -> Unit)? = null,
+    trailingIcon: (@Composable () -> Unit)? = null
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height = 52.dp)
+            .background(color = Color(0xffFAFAFA))
+    ) {
+        // 좌측 아이콘
+        Box(
+            modifier = modifier
+                .padding(horizontal = 30.dp)
+                .align(Alignment.CenterStart)
+        ) {
+            leadingIcon?.invoke()
+        }
+        // 제목
+        Text(
+            text = title, style = MaterialTheme.typography.titleMedium
+                .copy(
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 20.sp,
+                    lineHeight = 32.sp,
+                    textAlign = TextAlign.Center,
+                    fontFamily = PretendardFontFamily,
+                ).withLetterSpacingPercent(-2.5f),
+            color = DescGray,
+            modifier = modifier.align(Alignment.Center)
+        )
+        // 우측 아이콘
+        Box(
+            modifier = modifier
+                .padding(horizontal = 30.dp)
+                .align(Alignment.CenterEnd)
+        ) {
+            trailingIcon?.invoke()
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun SomeVerseTopBarPreview() {
+    SomeVerseTopBar(
+        title = "취향 입력",
+        leadingIcon = {
+            IconButton(
+                onClick = {}
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_dismiss),
+                    contentDescription = "뒤로가기",
+                    tint = Color(0xFF9098A6),
+                    modifier = Modifier.size(size = 28.dp)
+                )
+            }
+        },
+        trailingIcon = {
+            IconButton(
+                onClick = {}
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_search),
+                    contentDescription = "신고",
+                    tint = Color(0xff9098A6),
+                    modifier = Modifier.size(size = 20.dp)
+                )
+            }
+        }
+    )
+}

--- a/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
+++ b/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -35,7 +36,7 @@ fun SomeVerseTopBar(
     modifier: Modifier = Modifier,
     textTitle: String? = null,
     leadingIcon: (@Composable () -> Unit)? = null,
-    trailingIcons: List<@Composable () -> Unit> = emptyList()
+    trailingIcons: (@Composable RowScope.() -> Unit)? = null
 ) {
     Box(
         modifier = modifier
@@ -84,14 +85,12 @@ fun SomeVerseTopBar(
         }
 
         // 우측 아이콘 그룹 (Row 배치)
-        if (trailingIcons.isNotEmpty()) {
+        if (trailingIcons != null) {
             Row(
                 modifier = Modifier.align(Alignment.CenterEnd),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                trailingIcons.forEach { icon ->
-                    icon()
-                }
+                trailingIcons()
             }
         }
     }
@@ -114,18 +113,16 @@ fun SomeVerseTopBarPreview() {
                     )
                 }
             },
-            trailingIcons = listOf(
-                {
-                    IconButton(onClick = {}) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_search),
-                            contentDescription = "검색",
-                            tint = iconColor,
-                            modifier = Modifier.size(24.dp)
-                        )
-                    }
-                },
-            )
+            trailingIcons = {
+                IconButton(onClick = {}) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_search),
+                        contentDescription = "검색",
+                        tint = iconColor,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
         )
 
         Spacer(modifier = Modifier.height(Dimensions.space12))
@@ -143,28 +140,24 @@ fun SomeVerseTopBarPreview() {
                     )
                 }
             },
-            trailingIcons = listOf(
-                {
-                    IconButton(onClick = {}) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_search),
-                            contentDescription = "검색",
-                            tint = iconColor,
-                            modifier = Modifier.size(24.dp)
-                        )
-                    }
-                },
-                {
-                    IconButton(onClick = {}) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_add_image),
-                            contentDescription = "설정",
-                            tint = iconColor,
-                            modifier = Modifier.size(24.dp)
-                        )
-                    }
+            trailingIcons = {
+                IconButton(onClick = {}) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_search),
+                        contentDescription = "검색",
+                        tint = iconColor,
+                        modifier = Modifier.size(24.dp)
+                    )
                 }
-            )
+                IconButton(onClick = {}) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_add_image),
+                        contentDescription = "설정",
+                        tint = iconColor,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
         )
     }
 }

--- a/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
+++ b/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -33,16 +34,15 @@ import com.someverse.presentation.ui.theme.withLetterSpacingPercent
 fun SomeVerseTopBar(
     modifier: Modifier = Modifier,
     textTitle: String? = null,
-    titleImage: Boolean = false,
     leadingIcon: (@Composable () -> Unit)? = null,
-    trailingIcon: (@Composable () -> Unit)? = null
+    trailingIcons: List<@Composable () -> Unit> = emptyList()
 ) {
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(height = 52.dp)
-            .padding(horizontal = 30.dp)
             .background(color = Color(0xffFAFAFA))
+            .padding(horizontal = 30.dp)
     ) {
         // 좌측 아이콘
         if (leadingIcon != null) {
@@ -57,7 +57,8 @@ fun SomeVerseTopBar(
         // 텍스트 제목
         if (textTitle != null) {
             Text(
-                text = textTitle, style = MaterialTheme.typography.titleMedium
+                text = textTitle,
+                style = MaterialTheme.typography.titleMedium
                     .copy(
                         fontWeight = FontWeight.SemiBold,
                         fontSize = 20.sp,
@@ -70,7 +71,7 @@ fun SomeVerseTopBar(
         }
 
         // 이미지 제목
-        if (titleImage) {
+        if (textTitle == null) {
             Image(
                 painter = painterResource(id = R.drawable.ic_logo_with_text),
                 contentDescription = "SOMEVERSE 로고",
@@ -82,49 +83,49 @@ fun SomeVerseTopBar(
             )
         }
 
-        // 우측 아이콘
-        if (trailingIcon != null) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
+        // 우측 아이콘 그룹 (Row 배치)
+        if (trailingIcons.isNotEmpty()) {
+            Row(
+                modifier = Modifier.align(Alignment.CenterEnd),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                trailingIcon()
+                trailingIcons.forEach { icon ->
+                    icon()
+                }
             }
         }
     }
 }
 
 @Composable
-@Preview(showBackground = true)
+@Preview(showBackground = false)
 fun SomeVerseTopBarPreview() {
     val iconColor = Color(0xFF9098A6)
-    Column() {
+    Column {
         SomeVerseTopBar(
             textTitle = "취향 입력",
             leadingIcon = {
-                IconButton(
-                    onClick = {}
-                ) {
+                IconButton(onClick = {}) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_dismiss),
                         contentDescription = "뒤로가기",
                         tint = iconColor,
-                        modifier = Modifier.size(size = 28.dp)
+                        modifier = Modifier.size(28.dp)
                     )
                 }
             },
-            trailingIcon = {
-                IconButton(
-                    onClick = {}
-                ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_search),
-                        contentDescription = "신고",
-                        tint = iconColor,
-                        modifier = Modifier.size(size = 20.dp)
-                    )
-                }
-            }
+            trailingIcons = listOf(
+                {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_search),
+                            contentDescription = "검색",
+                            tint = iconColor,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                },
+            )
         )
 
         Spacer(modifier = Modifier.height(Dimensions.space12))
@@ -142,8 +143,28 @@ fun SomeVerseTopBarPreview() {
                     )
                 }
             },
-            titleImage = true
+            trailingIcons = listOf(
+                {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_search),
+                            contentDescription = "검색",
+                            tint = iconColor,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                },
+                {
+                    IconButton(onClick = {}) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_add_image),
+                            contentDescription = "설정",
+                            tint = iconColor,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+            )
         )
     }
-
 }

--- a/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
+++ b/presentation/src/main/java/com/someverse/presentation/components/SomeVerseTopBar.kt
@@ -29,12 +29,17 @@ import com.someverse.presentation.R
 import com.someverse.presentation.ui.theme.DescGray
 import com.someverse.presentation.ui.theme.Dimensions
 import com.someverse.presentation.ui.theme.PretendardFontFamily
-import com.someverse.presentation.ui.theme.withLetterSpacingPercent
+
+sealed interface TopBarTitle {
+    data class Text(val value: String) : TopBarTitle
+    data object Logo : TopBarTitle
+    data object None : TopBarTitle
+}
 
 @Composable
 fun SomeVerseTopBar(
     modifier: Modifier = Modifier,
-    textTitle: String? = null,
+    title: TopBarTitle = TopBarTitle.None,
     leadingIcon: (@Composable () -> Unit)? = null,
     trailingIcons: (@Composable RowScope.() -> Unit)? = null
 ) {
@@ -55,33 +60,38 @@ fun SomeVerseTopBar(
             }
         }
 
-        // 텍스트 제목
-        if (textTitle != null) {
-            Text(
-                text = textTitle,
-                style = MaterialTheme.typography.titleMedium
-                    .copy(
+        // 제목
+        when (title) {
+            // 텍스트 제목
+            is TopBarTitle.Text -> {
+                Text(
+                    text = title.value,
+                    style = MaterialTheme.typography.titleMedium.copy(
                         fontWeight = FontWeight.SemiBold,
                         fontSize = 20.sp,
-                        lineHeight = 32.sp,
                         fontFamily = PretendardFontFamily,
-                    ).withLetterSpacingPercent(-2.5f),
-                color = DescGray,
-                modifier = Modifier.align(Alignment.Center)
-            )
-        }
+                    ),
+                    color = DescGray,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
 
-        // 이미지 제목
-        if (textTitle == null) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_logo_with_text),
-                contentDescription = "SOMEVERSE 로고",
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .padding(start = if (leadingIcon != null) 60.dp else Dimensions.space16)
-                    .width(108.dp)
-                    .height(20.dp)
-            )
+            // 이미지 제목
+            is TopBarTitle.Logo -> {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_logo_with_text),
+                    contentDescription = "SOMEVERSE 로고",
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        // Leading Icon 유무에 따른 동적 패딩
+                        .padding(start = if (leadingIcon != null) 60.dp else Dimensions.space16)
+                        .width(108.dp)
+                        .height(20.dp)
+                )
+            }
+
+            // 제목 없음
+            TopBarTitle.None -> {}
         }
 
         // 우측 아이콘 그룹 (Row 배치)
@@ -102,7 +112,7 @@ fun SomeVerseTopBarPreview() {
     val iconColor = Color(0xFF9098A6)
     Column {
         SomeVerseTopBar(
-            textTitle = "취향 입력",
+            title = TopBarTitle.Text("취향 입력"),
             leadingIcon = {
                 IconButton(onClick = {}) {
                     Icon(
@@ -128,6 +138,7 @@ fun SomeVerseTopBarPreview() {
         Spacer(modifier = Modifier.height(Dimensions.space12))
 
         SomeVerseTopBar(
+            title = TopBarTitle.Logo,
             leadingIcon = {
                 IconButton(
                     onClick = {}

--- a/presentation/src/main/java/com/someverse/presentation/navigation/NavGraph.kt
+++ b/presentation/src/main/java/com/someverse/presentation/navigation/NavGraph.kt
@@ -11,6 +11,7 @@ import com.someverse.presentation.ui.auth.signup.SignupDoneScreen
 import com.someverse.presentation.ui.auth.signup.SignupLocationScreen
 import com.someverse.presentation.ui.auth.signup.SignupMovieCategoryScreen
 import com.someverse.presentation.ui.auth.signup.SignupMovieTasteScreen
+import com.someverse.presentation.ui.auth.signup.SignupNicknameScreen
 import com.someverse.presentation.ui.auth.signup.SignupProfileImageScreen
 import com.someverse.presentation.ui.chat.DetailChatScreen
 import com.someverse.presentation.ui.main.MainScreen
@@ -23,7 +24,7 @@ import com.someverse.presentation.ui.splash.SplashScreen
 @Composable
 fun NavGraph(
     navController: NavHostController,
-    startDestination: String = Screen.Splash.route, // 스플래시 화면으로 시작
+    startDestination: String = Screen.SignupNickname.route, // 스플래시 화면으로 시작
 ) {
     NavHost(
         navController = navController,
@@ -50,6 +51,16 @@ fun NavGraph(
                     navController.navigate(Screen.SignupLocation.route) {
                         popUpTo(Screen.Login.route) { inclusive = true }
                     }
+                },
+            )
+        }
+
+        composable(route = Screen.SignupNickname.route) {
+            SignupNicknameScreen(
+                onNextClick = {
+                    println("닉네임 작성 완료 -> 성별 입력 화면으로 이동 시작")
+                    navController.navigate(Screen.SignupProfileImage.route) //TODO: 성별 입력 화면으로 변경
+                    println("✅ 성별 입력 화면 네비게이션 호출 완료")
                 },
             )
         }

--- a/presentation/src/main/java/com/someverse/presentation/navigation/Screen.kt
+++ b/presentation/src/main/java/com/someverse/presentation/navigation/Screen.kt
@@ -14,6 +14,8 @@ sealed class Screen(
     data object Login : Screen("login")
 
     // Onboarding Screens
+    data object SignupNickname : Screen("signup_nickname")
+
     data object SignupLocation : Screen("signup_location")
 
     data object SignupProfileImage : Screen("signup_profile_image")

--- a/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupLocationScreen.kt
+++ b/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupLocationScreen.kt
@@ -7,11 +7,29 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,7 +47,14 @@ import com.someverse.presentation.components.CityList
 import com.someverse.presentation.components.DistrictList
 import com.someverse.presentation.components.GradientButton
 import com.someverse.presentation.components.LocationChip
-import com.someverse.presentation.ui.theme.*
+import com.someverse.presentation.components.PageIndicator
+import com.someverse.presentation.ui.theme.Black
+import com.someverse.presentation.ui.theme.DescGray
+import com.someverse.presentation.ui.theme.Dimensions
+import com.someverse.presentation.ui.theme.PretendardFontFamily
+import com.someverse.presentation.ui.theme.PrimaryPurple
+import com.someverse.presentation.ui.theme.withLetterSpacingPercent
+import com.someverse.presentation.ui.theme.withLineHeightPercent
 
 /**
  * 위치 정보 입력 화면
@@ -260,7 +285,8 @@ fun LocationSelectionSection(
                         .border(
                             width = 1.dp,
                             color = Color(0xFFEBEFF5).copy(alpha = 0.5f),
-                        ).background(Color(0xFFEBEFF5).copy(alpha = 0.5f)),
+                        )
+                        .background(Color(0xFFEBEFF5).copy(alpha = 0.5f)),
             ) {
                 // 도시 및 구/군 선택 영역을 Row로 배치
                 Row(modifier = Modifier.fillMaxWidth()) {
@@ -329,15 +355,4 @@ fun LocationSelectionSection(
     }
 }
 
-@Composable
-fun PageIndicator(isActive: Boolean) {
-    Box(
-        modifier =
-            Modifier
-                .size(width = 8.dp, height = 8.dp)
-                .clip(CircleShape)
-                .background(
-                    if (isActive) PrimaryPurple else Color(0xFFE4E8EF),
-                ),
-    )
-}
+

--- a/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameScreen.kt
+++ b/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameScreen.kt
@@ -1,0 +1,185 @@
+package com.someverse.presentation.ui.auth.signup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.someverse.presentation.components.GradientButton
+import com.someverse.presentation.components.Toast
+import com.someverse.presentation.ui.theme.Black
+import com.someverse.presentation.ui.theme.DescGray
+import com.someverse.presentation.ui.theme.Dimensions
+import com.someverse.presentation.ui.theme.PretendardFontFamily
+import com.someverse.presentation.ui.theme.SomeverseTheme
+import com.someverse.presentation.ui.theme.withLetterSpacingPercent
+
+@Composable
+fun SignupNicknameScreen(
+    onNextClick: () -> Unit = {},
+    viewModel: SignupNicknameViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    SignupNicknameScreenContent(
+        onNextClick = {
+            viewModel.submitNickname(onSuccess = onNextClick)
+        },
+        nickname = uiState.nickname,
+        onValueChange = viewModel::onValueChange,
+        errorMessage = uiState.errorMessage,
+        deleteErrorMessage = viewModel::deleteErrorMessage
+    )
+}
+
+@Composable
+private fun SignupNicknameScreenContent(
+    onNextClick: () -> Unit = {},
+    nickname: String,
+    onValueChange: (String) -> Unit,
+    errorMessage: String,
+    deleteErrorMessage: () -> Unit
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            // 상단 타이틀
+            Text(
+                text = "회원가입",
+                style =
+                    MaterialTheme.typography.titleMedium
+                        .copy(
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 20.sp,
+                            lineHeight = 32.sp,
+                            textAlign = TextAlign.Center,
+                            fontFamily = PretendardFontFamily,
+                        ).withLetterSpacingPercent(-2.5f),
+                color = DescGray,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(Dimensions.screenPadding),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // 상단 여백
+                Spacer(modifier = Modifier.height(Dimensions.space24))
+
+                // 제목
+                Text(
+                    text = "SOMEVERSE가 처음이시군요!\n닉네임을 정해주세요.",
+                    style = MaterialTheme.typography.displaySmall,
+                    textAlign = TextAlign.Start,
+                    color = Black,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(Dimensions.space12))
+
+                // 설명
+                Text(
+                    text = "흥미로운 닉네임일수록 매칭율이 높아져요!",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = DescGray,
+                    textAlign = TextAlign.Start,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                Spacer(modifier = Modifier.height(Dimensions.space12))
+
+                // 닉네임 입력 필드
+                TextField(
+                    value = nickname,
+                    onValueChange = onValueChange
+                )
+
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                // 페이지 인디케이터
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 24.dp),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    repeat(5) { index ->
+                        PageIndicator(isActive = index == 0)
+                        Spacer(modifier = Modifier.width(8.dp))
+                    }
+                }
+
+                // 다음 버튼 (그라데이션 배경)
+                GradientButton(
+                    text = "닉네임 결정하기",
+                    onClick = {
+                        println("📦 '닉네임 결정하기' 버튼 클릭 -> 닉네임 중복 여부 검사")
+                        onNextClick()
+                    },
+                    enabled = nickname.isNotEmpty(),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(60.dp)
+                            .padding(horizontal = Dimensions.space8),
+                )
+
+                Spacer(modifier = Modifier.height(Dimensions.space48))
+            }
+        }
+
+        // Toast 메시지 (하단에 표시)
+        Toast(
+            message = errorMessage,
+//            onDismiss = { /* 에러 메시지 자동 사라짐 */ },
+            onDismiss = { deleteErrorMessage() },
+            duration = 3000L,
+            isError = true,
+            modifier =
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 100.dp),
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+fun SignupNicknameScreenPreView() {
+    SomeverseTheme {
+        SignupNicknameScreenContent(
+            nickname = "썸버스유저",
+            onValueChange = {},
+            onNextClick = {},
+            errorMessage = "",
+            deleteErrorMessage = {}
+        )
+    }
+}

--- a/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameScreen.kt
+++ b/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameScreen.kt
@@ -1,5 +1,7 @@
 package com.someverse.presentation.ui.auth.signup
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,22 +11,38 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.someverse.presentation.R
 import com.someverse.presentation.components.GradientButton
+import com.someverse.presentation.components.PageIndicator
+import com.someverse.presentation.components.SomeVerseTopBar
 import com.someverse.presentation.components.Toast
 import com.someverse.presentation.ui.theme.Black
 import com.someverse.presentation.ui.theme.DescGray
@@ -40,133 +58,205 @@ fun SignupNicknameScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     SignupNicknameScreenContent(
-        onNextClick = {
-            viewModel.submitNickname(onSuccess = onNextClick)
+        onButtonClick = {
+            if (uiState.isNicknameAvailable) {
+                onNextClick()
+            } else {
+                viewModel.validateNickname()
+            }
         },
         nickname = uiState.nickname,
         onValueChange = viewModel::onValueChange,
         errorMessage = uiState.errorMessage,
+        isNicknameAvailable = uiState.isNicknameAvailable,
         deleteErrorMessage = viewModel::deleteErrorMessage
     )
 }
 
 @Composable
 private fun SignupNicknameScreenContent(
-    onNextClick: () -> Unit = {},
+    onButtonClick: () -> Unit,
     nickname: String,
     onValueChange: (String) -> Unit,
     errorMessage: String,
+    isNicknameAvailable: Boolean,
     deleteErrorMessage: () -> Unit
 ) {
+    // 이미지 로고
+    val myId = "inlineLogo"
+    val inlineContent = mapOf(
+        myId to InlineTextContent(
+            Placeholder(
+                width = 100.sp,
+                height = 20.sp,
+                placeholderVerticalAlign = PlaceholderVerticalAlign.Top
+            )
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_logo_with_text),
+                contentDescription = "SOMEVERSE 로고",
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    )
+
+    val annotatedString = buildAnnotatedString {
+        // 로고 삽입
+        appendInlineContent(myId, "[logo]")
+        append(" 가 처음이시군요!\n닉네임을 정해주세요.")
+    }
+
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(),
     ) {
         Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(Dimensions.screenPadding),
         ) {
             // 상단 타이틀
+            SomeVerseTopBar(title = "회원가입")
+
+            // 상단 여백
+            Spacer(modifier = Modifier.height(Dimensions.space16))
+
+            // 제목
             Text(
-                text = "회원가입",
-                style =
-                    MaterialTheme.typography.titleMedium
-                        .copy(
-                            fontWeight = FontWeight.SemiBold,
-                            fontSize = 20.sp,
-                            lineHeight = 32.sp,
-                            textAlign = TextAlign.Center,
-                            fontFamily = PretendardFontFamily,
-                        ).withLetterSpacingPercent(-2.5f),
+                text = annotatedString,
+                inlineContent = inlineContent,
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontFamily = PretendardFontFamily,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 21.sp,
+                    lineHeight = 31.5.sp,
+                    platformStyle = PlatformTextStyle(includeFontPadding = false)
+                ).withLetterSpacingPercent(-2.5f),
+                textAlign = TextAlign.Start,
+                color = Black,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(modifier = Modifier.height(Dimensions.space4))
+
+            // 설명
+            Text(
+                text = "흥미로운 닉네임일수록 매칭율이 높아져요!",
+                style = MaterialTheme.typography.bodySmall.copy(
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 14.sp,
+                    lineHeight = 22.sp,
+                    textAlign = TextAlign.Start,
+                    fontFamily = PretendardFontFamily,
+                ).withLetterSpacingPercent(-2.5f),
                 color = DescGray,
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(Dimensions.screenPadding),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                // 상단 여백
-                Spacer(modifier = Modifier.height(Dimensions.space24))
+            Spacer(modifier = Modifier.height(Dimensions.space16))
 
-                // 제목
-                Text(
-                    text = "SOMEVERSE가 처음이시군요!\n닉네임을 정해주세요.",
-                    style = MaterialTheme.typography.displaySmall,
-                    textAlign = TextAlign.Start,
-                    color = Black,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-
-                Spacer(modifier = Modifier.height(Dimensions.space12))
-
-                // 설명
-                Text(
-                    text = "흥미로운 닉네임일수록 매칭율이 높아져요!",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = DescGray,
-                    textAlign = TextAlign.Start,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-
-                Spacer(modifier = Modifier.height(Dimensions.space12))
-
+            Column {
                 // 닉네임 입력 필드
                 TextField(
                     value = nickname,
-                    onValueChange = onValueChange
-                )
-
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                // 페이지 인디케이터
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 24.dp),
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    repeat(5) { index ->
-                        PageIndicator(isActive = index == 0)
-                        Spacer(modifier = Modifier.width(8.dp))
-                    }
-                }
-
-                // 다음 버튼 (그라데이션 배경)
-                GradientButton(
-                    text = "닉네임 결정하기",
-                    onClick = {
-                        println("📦 '닉네임 결정하기' 버튼 클릭 -> 닉네임 중복 여부 검사")
-                        onNextClick()
+                    onValueChange = onValueChange,
+                    placeholder = {
+                        Text(
+                            text = "닉네임을 설정하세요",
+                            color = Color(0xFFADB5BD)
+                        )
                     },
-                    enabled = nickname.isNotEmpty(),
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .height(60.dp)
-                            .padding(horizontal = Dimensions.space8),
+                    leadingIcon = {
+                        if (nickname.isNotEmpty()) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_my_profile),
+                                contentDescription = null,
+                                tint = Color(0xFFADB5BD),
+                                modifier = Modifier.size(24.dp)
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(66.dp)
+                        .clip(RoundedCornerShape(16.dp)),
+
+                    // 에러 상태 설정 (메시지가 있으면 에러)
+                    isError = errorMessage.isNotEmpty(),
+
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color(0xFFEDF1F7),
+                        unfocusedContainerColor = Color(0xFFEDF1F7),
+                        errorContainerColor = Color(0xFFEDF1F7),
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        disabledIndicatorColor = Color.Transparent,
+                        errorIndicatorColor = Color.Transparent
+                    ),
+                    textStyle = TextStyle(
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = if (errorMessage.isNotEmpty()) Color.Red else Color(0xFF495057)
+                    ),
+                    singleLine = true
                 )
-
-                Spacer(modifier = Modifier.height(Dimensions.space48))
+                if (isNicknameAvailable) {
+                    Text(
+                        text = "사용 가능한 닉네임이에요.",
+                        color = Color(0xFF4CAF50),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                }
             }
-        }
 
-        // Toast 메시지 (하단에 표시)
-        Toast(
-            message = errorMessage,
-//            onDismiss = { /* 에러 메시지 자동 사라짐 */ },
-            onDismiss = { deleteErrorMessage() },
-            duration = 3000L,
-            isError = true,
-            modifier =
-                Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = 100.dp),
-        )
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 에러 토스트
+            if (errorMessage.isNotEmpty()) {
+                Toast(
+                    message = errorMessage,
+                    onDismiss = { deleteErrorMessage() },
+                    duration = 3000L,
+                    isError = true,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+            }
+
+            // 페이지 인디케이터
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                repeat(5) { index ->
+                    PageIndicator(isActive = index == 0)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+            }
+
+            // 다음 버튼 (그라데이션 배경)
+            GradientButton(
+                text = "닉네임 결정하기",
+                onClick = {
+                    println("📦 '닉네임 결정하기' 버튼 클릭 -> 닉네임 중복 여부 검사")
+                    onButtonClick()
+                },
+                enabled = nickname.isNotEmpty(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(60.dp)
+                        .padding(horizontal = Dimensions.space8),
+            )
+
+            Spacer(modifier = Modifier.height(Dimensions.space48))
+        }
     }
 }
 
@@ -177,9 +267,10 @@ fun SignupNicknameScreenPreView() {
         SignupNicknameScreenContent(
             nickname = "썸버스유저",
             onValueChange = {},
-            onNextClick = {},
             errorMessage = "",
-            deleteErrorMessage = {}
+            isNicknameAvailable = false,
+            deleteErrorMessage = {},
+            onButtonClick = {}
         )
     }
 }

--- a/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameScreen.kt
+++ b/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameScreen.kt
@@ -44,6 +44,7 @@ import com.someverse.presentation.components.GradientButton
 import com.someverse.presentation.components.PageIndicator
 import com.someverse.presentation.components.SomeVerseTopBar
 import com.someverse.presentation.components.Toast
+import com.someverse.presentation.components.TopBarTitle
 import com.someverse.presentation.ui.theme.Black
 import com.someverse.presentation.ui.theme.DescGray
 import com.someverse.presentation.ui.theme.Dimensions
@@ -119,7 +120,7 @@ private fun SignupNicknameScreenContent(
                     .padding(Dimensions.screenPadding),
         ) {
             // 상단 타이틀
-            SomeVerseTopBar(title = "회원가입")
+            SomeVerseTopBar(title = TopBarTitle.Text("회원가입"))
 
             // 상단 여백
             Spacer(modifier = Modifier.height(Dimensions.space16))

--- a/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameUiState.kt
+++ b/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameUiState.kt
@@ -1,0 +1,6 @@
+package com.someverse.presentation.ui.auth.signup
+
+data class SignupNicknameUiState(
+    val nickname: String = "",
+    val errorMessage: String = ""
+)

--- a/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameUiState.kt
+++ b/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameUiState.kt
@@ -2,5 +2,6 @@ package com.someverse.presentation.ui.auth.signup
 
 data class SignupNicknameUiState(
     val nickname: String = "",
-    val errorMessage: String = ""
+    val errorMessage: String = "",
+    val isNicknameAvailable: Boolean = false
 )

--- a/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameViewModel.kt
+++ b/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameViewModel.kt
@@ -1,0 +1,46 @@
+package com.someverse.presentation.ui.auth.signup
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.someverse.domain.usecase.onboarding.SubmitNicknameUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SignupNicknameViewModel
+@Inject
+constructor(
+    private val submitNicknameUseCase: SubmitNicknameUseCase
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(SignupNicknameUiState())
+    val uiState: StateFlow<SignupNicknameUiState> = _uiState.asStateFlow()
+
+    fun onValueChange(value: String) {
+        _uiState.update { it ->
+            it.copy(nickname = value)
+        }
+    }
+
+    fun submitNickname(onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            submitNicknameUseCase(nickname = _uiState.value.nickname)
+                .onSuccess { user ->
+                    _uiState.update { it.copy(errorMessage = "") }
+                    onSuccess()
+                }
+                .onFailure { error ->
+                    val errorMsg = error.message ?: "에러 발생"
+                    _uiState.update { it.copy(errorMessage = errorMsg) }
+                }
+        }
+    }
+
+    fun deleteErrorMessage() {
+        _uiState.update { it.copy(errorMessage = "") }
+    }
+}

--- a/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameViewModel.kt
+++ b/presentation/src/main/java/com/someverse/presentation/ui/auth/signup/SignupNicknameViewModel.kt
@@ -21,21 +21,28 @@ constructor(
     val uiState: StateFlow<SignupNicknameUiState> = _uiState.asStateFlow()
 
     fun onValueChange(value: String) {
-        _uiState.update { it ->
-            it.copy(nickname = value)
+        _uiState.update {
+            it.copy(nickname = value, isNicknameAvailable = false, errorMessage = "")
         }
     }
 
-    fun submitNickname(onSuccess: () -> Unit) {
+    fun validateNickname() {
+        val currentNickname = _uiState.value.nickname
+        if (currentNickname.isBlank()) return
+
         viewModelScope.launch {
-            submitNicknameUseCase(nickname = _uiState.value.nickname)
-                .onSuccess { user ->
-                    _uiState.update { it.copy(errorMessage = "") }
-                    onSuccess()
+            submitNicknameUseCase(nickname = currentNickname)
+                .onSuccess {
+                    _uiState.update { it.copy(isNicknameAvailable = true, errorMessage = "") }
                 }
                 .onFailure { error ->
-                    val errorMsg = error.message ?: "에러 발생"
-                    _uiState.update { it.copy(errorMessage = errorMsg) }
+                    val errorMsg = error.message ?: "이미 사용 중인 닉네임입니다."
+                    _uiState.update {
+                        it.copy(
+                            isNicknameAvailable = false,
+                            errorMessage = errorMsg
+                        )
+                    }
                 }
         }
     }

--- a/presentation/src/main/res/xml/file_paths.xml
+++ b/presentation/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path name="internal_files" path="." />
+    <external-path name="external_files" path="." />
+    <cache-path name="cache_files" path="." />
+</paths>


### PR DESCRIPTION
- add screen
- add viewModel
- add uiState
- modified submitNicknameUseCase(add checkNickname)
- modified AuthReoisitory(add checkNickname)
- modified AuthDataSource(add checkNickname)
- modified Navigator(add SignupNicknameScreen)

# 작업내역
- 요약: 신규 기능 추가

---

<!-- 🆕 기능 추가 템플릿 (해당 시 사용) -->
## [온보딩(닉네임 설정)] 기능 추가
- ✨ 기능 설명
    - 사용자가 온보딩시 닉네임을 설정할 수 있는 기능 추가

- 🎯 구현 목적
    - 사용자 계정 구분을 위해 최초 온보딩시 닉네임 설정 기능 필요

- 🛠️ 구현 내용
    - 주요 구현 사항 나열
        - 닉네임 설정 UI 구현
        - 닉네임 중복 체크 기능 적용
        - 닉네임 중복에 따른 분기 적용
            - 닉네임 중복시: 닉네임 중복 토스트 노출(3초 후 토스트 제거)
            - 닉네임 중복되지 않을시: 다음 스텝 이동

- 📸 결과물
  |스크린샷/영상|
  |:-:|
  |<video src="https://github.com/user-attachments/assets/a749097c-50f6-423c-8a83-f837fc0adbf1" />|

---