### PR TITLE
refactor: apply scaffold inner padding to NavGraph container

### DIFF
--- a/presentation/src/main/java/com/someverse/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/someverse/presentation/MainActivity.kt
@@ -6,11 +6,11 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.core.view.WindowCompat
 import androidx.navigation.compose.rememberNavController
 import com.someverse.presentation.navigation.NavGraph
 import com.someverse.presentation.ui.auth.login.LoginScreen
@@ -41,7 +41,11 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     containerColor = androidx.compose.ui.graphics.Color.Transparent
                 ) {
-                    Box(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = Modifier
+                            .padding(it)
+                            .fillMaxSize()
+                    ) {
                         NavGraph(navController = navController)
                     }
                 }


### PR DESCRIPTION
# 작업내역
- Scaffold 내부 콘텐츠 레이아웃 버그 수정

---

<!-- 🔧 버그 수정/개선 템플릿 (해당 시 사용) -->
## 1. [수정 제목 또는 간단 설명]
- 🚨 문제점
    - Scaffold 내부의 콘텐츠(NavGraph)가 시스템 바(상태 표시줄 및 네비게이션 바) 영역과 겹쳐서 출력되는 현상 발생

- 🔍 원인 분석
    - enableEdgeToEdge() 설정으로 인해 앱이 화면 전체 영역을 사용하게 되었으나, Scaffold가 계산해 주는 시스템 영역 패딩값(PaddingValues)을 내부 컨테이너에 적용하지 않아 콘텐츠가 시스템 UI 아래로 파고듦

- 💡 해결 방법
    - Scaffold 콘텐츠 블록에서 전달받는 it(PaddingValues)을 Box 컨테이너의 Modifier.padding(it)에 할당하여 시스템 바 영역만큼의 여백을 강제 적용
    - 더 이상 사용하지 않는 WindowCompat 관련 레거시 임포트 제거

- 🔄 수정 전/후 비교
  |수정 전|수정 후|
  |:-:|:-:|
  |<video src="" />|<video src="" />|